### PR TITLE
Update Explosive Projectiles

### DIFF
--- a/Projectiles/ArenaBuilderProjectile.cs
+++ b/Projectiles/ArenaBuilderProjectile.cs
@@ -22,6 +22,10 @@ namespace ExtraExplosives.Projectiles
 {
     public class ArenaBuilderProjectile : ModProjectile
     {
+        
+        // Variables
+        private const int PickPower = 0;
+        
         public override void SetStaticDefaults()
         {
             DisplayName.SetDefault("ArenaBuilder");
@@ -87,7 +91,8 @@ namespace ExtraExplosives.Projectiles
 
                     if (!OutOfBounds(xPosition, yPosition))
                     {
-                        if (CheckForUnbreakableTiles(Main.tile[xPosition, yPosition].type)) //Unbreakable
+                        ushort tile = Main.tile[xPosition, yPosition].type;
+                        if (CheckForUnbreakableTiles(tile) || !CanBreakTile(tile, PickPower)) //Unbreakable
                         {
                             if (Main.tile[xPosition, yPosition].type == TileID.BlueDungeonBrick || Main.tile[xPosition, yPosition].type == TileID.GreenDungeonBrick
                                 || Main.tile[xPosition, yPosition].type == TileID.PinkDungeonBrick || Main.tile[xPosition, yPosition].type == TileID.DesertFossil)

--- a/Projectiles/AtomBombProjectile.cs
+++ b/Projectiles/AtomBombProjectile.cs
@@ -22,6 +22,10 @@ namespace ExtraExplosives.Projectiles
 {
     public class AtomBombProjectile : ModProjectile
     {
+        
+        //Variables
+        private const int PickPower = -1;
+        
         public override void SetStaticDefaults()
         {
             DisplayName.SetDefault("Atom Bomb");
@@ -58,10 +62,14 @@ namespace ExtraExplosives.Projectiles
 
         private void CreateExplosion(Vector2 position, int radius)
         {
-            int xPosition = (int)(position.X / 16.0f);
-            int yPosition = (int)(position.Y / 16.0f);
-            WorldGen.KillTile(xPosition, yPosition, false, false, true);  //this make the explosion destroy tiles  
-        }
+            int xPosition = (int) (position.X / 16.0f);
+            int yPosition = (int) (position.Y / 16.0f);
+            ushort tile = Main.tile[xPosition, yPosition].type;
+            if (CanBreakTile(tile, PickPower)) // Add this to allow for some level of control of what it can break
+            {                                  // Pickaxe Power is currently set to -1, so the method is set to default to true
+                WorldGen.KillTile(xPosition, yPosition, false, false, true); //this make the explosion destroy tiles  
+            }
+    }
 
         private void CreateDust(Vector2 position, int amount)
         {

--- a/Projectiles/BasicExplosiveProjectile.cs
+++ b/Projectiles/BasicExplosiveProjectile.cs
@@ -22,6 +22,10 @@ namespace ExtraExplosives.Projectiles
 {
     public class BasicExplosiveProjectile : ModProjectile
     {
+        
+        //Variables
+        private const int PickPower = 0;
+        
         public override void SetStaticDefaults()
         {
             DisplayName.SetDefault("BasicExplosive");
@@ -65,7 +69,8 @@ namespace ExtraExplosives.Projectiles
 
                     if (Math.Sqrt(x * x + y * y) <= radius + 0.5 && (WorldGen.InWorld(xPosition, yPosition))) //Circle
                     {
-                        if (CheckForUnbreakableTiles(Main.tile[xPosition, yPosition].type)) //Unbreakable
+                        ushort tile = Main.tile[xPosition, yPosition].type;
+                        if (CheckForUnbreakableTiles(tile) || !CanBreakTile(tile, PickPower)) //Unbreakable
                         {
 
                         }

--- a/Projectiles/BigBouncyDynamiteProjectile.cs
+++ b/Projectiles/BigBouncyDynamiteProjectile.cs
@@ -22,6 +22,10 @@ namespace ExtraExplosives.Projectiles
 {
     public class BigBouncyDynamiteProjectile : ModProjectile
     {
+        
+        //Variables
+        private const int PickPower = 0;
+        
         public override void SetStaticDefaults()
         {
             DisplayName.SetDefault("BigBouncyDynamite");
@@ -86,7 +90,8 @@ namespace ExtraExplosives.Projectiles
 
                     if (Math.Sqrt(x * x + y * y) <= radius + 0.5 && (WorldGen.InWorld(xPosition, yPosition))) //Circle
                     {
-                        if (CheckForUnbreakableTiles(Main.tile[xPosition, yPosition].type)) //Unbreakable
+                        ushort tile = Main.tile[xPosition, yPosition].type;
+                        if (CheckForUnbreakableTiles(tile) || !CanBreakTile(tile, PickPower)) //Unbreakable
                         {
 
                         }

--- a/Projectiles/BoomerangProjectile.cs
+++ b/Projectiles/BoomerangProjectile.cs
@@ -9,7 +9,6 @@ namespace ExtraExplosives.Projectiles
 {
     public class BoomerangProjectile : ModProjectile
     {
-
         public override void SetStaticDefaults()
         {
             DisplayName.SetDefault("BOOMerang");

--- a/Projectiles/BreakenTheBankenProjectile.cs
+++ b/Projectiles/BreakenTheBankenProjectile.cs
@@ -22,6 +22,10 @@ namespace ExtraExplosives.Projectiles
 {
     public class BreakenTheBankenProjectile : ModProjectile
     {
+        
+        // Variables
+        private const int PickPower = 0;
+        
         public override void SetStaticDefaults()
         {
             DisplayName.SetDefault("BreakenTheBanken");
@@ -66,7 +70,8 @@ namespace ExtraExplosives.Projectiles
 
                     if (Math.Sqrt(x * x + y * y) <= radius + 0.5 && (WorldGen.InWorld(xPosition, yPosition))) //Circle
                     {
-                        if (CheckForUnbreakableTiles(Main.tile[xPosition, yPosition].type)) //Unbreakable
+                        ushort tile = Main.tile[xPosition, yPosition].type;
+                        if (CheckForUnbreakableTiles(tile) || !CanBreakTile(tile, PickPower)) //Unbreakable
                         {
 
                         }

--- a/Projectiles/C4Projectile.cs
+++ b/Projectiles/C4Projectile.cs
@@ -13,6 +13,7 @@ namespace ExtraExplosives.Projectiles
         //Variables:
         private bool freeze;
         private Vector2 positionToFreeze;
+        private const int PickPower = 0;
 
         public override void SetStaticDefaults()
         {
@@ -100,7 +101,8 @@ namespace ExtraExplosives.Projectiles
 
                     if (Math.Sqrt(x * x + y * y) <= radius + 0.5 && (WorldGen.InWorld(xPosition, yPosition))) //Circle
                     {
-                        if (CheckForUnbreakableTiles(Main.tile[xPosition, yPosition].type)) //Unbreakable
+                        ushort tile = Main.tile[xPosition, yPosition].type;
+                        if (CheckForUnbreakableTiles(tile) || !CanBreakTile(tile, PickPower)) //Unbreakable
                         {
                             if (Main.tile[xPosition, yPosition].type == TileID.DesertFossil)
                             {

--- a/Projectiles/ClusterBombChildProjectile.cs
+++ b/Projectiles/ClusterBombChildProjectile.cs
@@ -22,6 +22,10 @@ namespace ExtraExplosives.Projectiles
 {
     public class ClusterBombChildProjectile : ModProjectile
     {
+        
+        // Variables
+        private const int PickPower = 0;
+        
         public override void SetStaticDefaults()
         {
             DisplayName.SetDefault("ClusterBomb");
@@ -66,7 +70,8 @@ namespace ExtraExplosives.Projectiles
 
                     if (Math.Sqrt(x * x + y * y) <= radius + 0.5 && (WorldGen.InWorld(xPosition, yPosition))) //Circle
                     {
-                        if (CheckForUnbreakableTiles(Main.tile[xPosition, yPosition].type)) //Unbreakable
+                        ushort tile = Main.tile[xPosition, yPosition].type;
+                        if (CheckForUnbreakableTiles(tile) || !CanBreakTile(tile, PickPower)) //Unbreakable
                         {
 
                         }

--- a/Projectiles/ClusterBombProjectile.cs
+++ b/Projectiles/ClusterBombProjectile.cs
@@ -9,10 +9,14 @@ namespace ExtraExplosives.Projectiles
 {
     public class ClusterBombProjectile : ModProjectile
     {
+        
+        // Variables
         Mod CalamityMod = ModLoader.GetMod("CalamityMod");
         Mod ThoriumMod = ModLoader.GetMod("ThoriumMod");
 
         internal static bool CanBreakWalls;
+        private const int PickPower = 0;
+        
         public override void SetStaticDefaults()
         {
             DisplayName.SetDefault("ClusterBomb");
@@ -93,7 +97,8 @@ namespace ExtraExplosives.Projectiles
 
                     if (Math.Sqrt(x * x + y * y) <= radius + 0.5 && (WorldGen.InWorld(xPosition, yPosition))) //Circle
                     {
-                        if (CheckForUnbreakableTiles(Main.tile[xPosition, yPosition].type)) //Unbreakable
+                        ushort tile = Main.tile[xPosition, yPosition].type;
+                        if (CheckForUnbreakableTiles(tile) || !CanBreakTile(tile, PickPower)) //Unbreakable
                         {
 
                         }

--- a/Projectiles/DaBombProjectile.cs
+++ b/Projectiles/DaBombProjectile.cs
@@ -24,6 +24,7 @@ namespace ExtraExplosives.Projectiles
     {
         //Variables:
         public bool buffActive;
+        private const int PickPower = 0;
 
         public override void SetStaticDefaults()
         {
@@ -86,7 +87,8 @@ namespace ExtraExplosives.Projectiles
 
                     if (Math.Sqrt(x * x + y * y) <= radius + 0.5 && (WorldGen.InWorld(xPosition, yPosition))) //Circle
                     {
-                        if (CheckForUnbreakableTiles(Main.tile[xPosition, yPosition].type)) //Unbreakable
+                        ushort tile = Main.tile[xPosition, yPosition].type;
+                        if (CheckForUnbreakableTiles(tile) || !CanBreakTile(tile, PickPower)) //Unbreakable
                         {
 
                         }

--- a/Projectiles/DeliquidifierProjectile.cs
+++ b/Projectiles/DeliquidifierProjectile.cs
@@ -22,6 +22,10 @@ namespace ExtraExplosives.Projectiles
 {
     public class DeliquidifierProjectile : ModProjectile
     {
+        
+        // Variables
+        private const int PickPower = 0;
+        
         public override void SetStaticDefaults()
         {
             DisplayName.SetDefault("Deliquidifier");
@@ -64,13 +68,14 @@ namespace ExtraExplosives.Projectiles
 
                     if (Math.Sqrt(x * x + y * y) <= radius + 0.5 && (WorldGen.InWorld(xPosition, yPosition))) //Circle
                     {
-                        if (CheckForUnbreakableTiles(Main.tile[xPosition, yPosition].type)) //Unbreakable
+                        ushort tile = Main.tile[xPosition, yPosition].type;
+                        if (CheckForUnbreakableTiles(tile) || !CanBreakTile(tile, PickPower)) //Unbreakable
                         {
 
                         }
                         else //Breakable
                         {
-                            
+                            // Fairly sure this doesnt need to be here (if and else) left in just in case im missing something
                         }
 
                         Main.tile[xPosition, yPosition].liquid = Tile.Liquid_Water; //Removes Liquid

--- a/Projectiles/ExplosionDamageProjectile.cs
+++ b/Projectiles/ExplosionDamageProjectile.cs
@@ -23,6 +23,7 @@ namespace ExtraExplosives.Projectiles
 {
     public class ExplosionDamageProjectile : ModProjectile
     {
+        
         //Variables:
         internal static float DamageRadius;
 

--- a/Projectiles/GiganticExplosiveProjectile.cs
+++ b/Projectiles/GiganticExplosiveProjectile.cs
@@ -22,6 +22,10 @@ namespace ExtraExplosives.Projectiles
 {
     public class GiganticExplosiveProjectile : ModProjectile
     {
+        
+        // Variables
+        private const int PickPower = 0;
+        
         public override void SetStaticDefaults()
         {
             DisplayName.SetDefault("GiganticExplosive");
@@ -73,7 +77,8 @@ namespace ExtraExplosives.Projectiles
 
                     if (Math.Sqrt(x * x + y * y) <= radius + 0.5 && (WorldGen.InWorld(xPosition, yPosition))) //Circle
                     {
-                        if (CheckForUnbreakableTiles(Main.tile[xPosition, yPosition].type)) //Unbreakable
+                        ushort tile = Main.tile[xPosition, yPosition].type;
+                        if (CheckForUnbreakableTiles(tile) || !CanBreakTile(tile, PickPower)) //Unbreakable
                         {
                             if (Main.tile[xPosition, yPosition].type == TileID.BlueDungeonBrick || Main.tile[xPosition, yPosition].type == TileID.GreenDungeonBrick
                                 || Main.tile[xPosition, yPosition].type == TileID.PinkDungeonBrick||

--- a/Projectiles/HeavyBombProjectile.cs
+++ b/Projectiles/HeavyBombProjectile.cs
@@ -22,6 +22,10 @@ namespace ExtraExplosives.Projectiles
 {
     public class HeavyBombProjectile : ModProjectile
     {
+        
+        // Variables
+        private const int PickPower = 0;
+        
         public override void SetStaticDefaults()
         {
             DisplayName.SetDefault("HeavyBomb");
@@ -59,7 +63,8 @@ namespace ExtraExplosives.Projectiles
 
                     if (Math.Sqrt(x * x + y * y) <= radius + 0.5 && (WorldGen.InWorld(xPosition, yPosition))) //Circle
                     {
-                        if (CheckForUnbreakableTiles(Main.tile[xPosition, yPosition].type)) //Unbreakable
+                        ushort tile = Main.tile[xPosition, yPosition].type;
+                        if (CheckForUnbreakableTiles(tile) || !CanBreakTile(tile, PickPower)) //Unbreakable
                         {
 
                         }

--- a/Projectiles/HellavatorProjectile.cs
+++ b/Projectiles/HellavatorProjectile.cs
@@ -22,6 +22,10 @@ namespace ExtraExplosives.Projectiles
 {
     public class HellavatorProjectile : ModProjectile
     {
+        
+        // Variables
+        private const int PickPower = 0;
+        
         public override void SetStaticDefaults()
         {
             DisplayName.SetDefault("Hellavator Projectile");
@@ -86,8 +90,8 @@ namespace ExtraExplosives.Projectiles
 
                     if (WorldGen.InWorld(xPosition, yPosition))
                     {
-                        
-                        if (CheckForUnbreakableTiles(Main.tile[xPosition, yPosition].type)) //Unbreakable
+                        ushort tile = Main.tile[xPosition, yPosition].type;
+                        if (CheckForUnbreakableTiles(tile) || !CanBreakTile(tile, PickPower)) //Unbreakable
                         {
                             
                         }

--- a/Projectiles/HouseBombProjectile.cs
+++ b/Projectiles/HouseBombProjectile.cs
@@ -22,6 +22,10 @@ namespace ExtraExplosives.Projectiles
 {
     public class HouseBombProjectile : ModProjectile
     {
+        
+        // Variables
+        private const int PickPower = 0;
+        
         public override void SetStaticDefaults()
         {
             DisplayName.SetDefault("HouseBomb");
@@ -88,7 +92,8 @@ namespace ExtraExplosives.Projectiles
 
                     if (WorldGen.InWorld(xPosition, yPosition))
                     {
-                        if (CheckForUnbreakableTiles(Main.tile[xPosition, yPosition].type)) //Unbreakable
+                        ushort tile = Main.tile[xPosition, yPosition].type;
+                        if (CheckForUnbreakableTiles(tile) || !CanBreakTile(tile, PickPower)) //Unbreakable
                         {
 
                         }

--- a/Projectiles/HydromiteProjectile.cs
+++ b/Projectiles/HydromiteProjectile.cs
@@ -22,6 +22,10 @@ namespace ExtraExplosives.Projectiles
 {
     public class HydromiteProjectile : ModProjectile
     {
+        
+        // Variables
+        private const int PickPower = 0;
+        
         public override void SetStaticDefaults()
         {
             DisplayName.SetDefault("Hydromite");
@@ -64,13 +68,14 @@ namespace ExtraExplosives.Projectiles
 
                     if (Math.Sqrt(x * x + y * y) <= radius + 0.5 && (WorldGen.InWorld(xPosition, yPosition))) //Circle
                     {
-                        if (CheckForUnbreakableTiles(Main.tile[xPosition, yPosition].type)) //Unbreakable
+                        ushort tile = Main.tile[xPosition, yPosition].type;
+                        if (CheckForUnbreakableTiles(tile) || !CanBreakTile(tile, PickPower)) //Unbreakable
                         {
 
                         }
                         else //Breakable
                         {
-                            
+                            // Doesnt seem necessary, left in anyways
                         }
 
                         if (WorldGen.TileEmpty((int)(x + position.X / 16.0f), (int)(y + position.Y / 16.0f)))

--- a/Projectiles/LargeExplosiveProjectile.cs
+++ b/Projectiles/LargeExplosiveProjectile.cs
@@ -22,6 +22,10 @@ namespace ExtraExplosives.Projectiles
 {
     public class LargeExplosiveProjectile : ModProjectile
     {
+        
+        // Variables
+        private const int PickPower = 0;
+        
         public override void SetStaticDefaults()
         {
             DisplayName.SetDefault("LargeExplosive");
@@ -66,7 +70,8 @@ namespace ExtraExplosives.Projectiles
 
                     if (Math.Sqrt(x * x + y * y) <= radius + 0.5 && (WorldGen.InWorld(xPosition, yPosition))) //Circle
                     {
-                        if (CheckForUnbreakableTiles(Main.tile[xPosition, yPosition].type)) //Unbreakable
+                        ushort tile = Main.tile[xPosition, yPosition].type;
+                        if (CheckForUnbreakableTiles(tile) || !CanBreakTile(tile, PickPower)) //Unbreakable
                         {
 
                         }

--- a/Projectiles/LavamiteProjectile.cs
+++ b/Projectiles/LavamiteProjectile.cs
@@ -22,6 +22,10 @@ namespace ExtraExplosives.Projectiles
 {
     public class LavamiteProjectile : ModProjectile
     {
+        
+        // Variables
+        private const int PickPower = 0;
+        
         public override void SetStaticDefaults()
         {
             DisplayName.SetDefault("Lavamite");
@@ -71,13 +75,14 @@ namespace ExtraExplosives.Projectiles
 
                     if (Math.Sqrt(x * x + y * y) <= radius + 0.5 && (WorldGen.InWorld(xPosition, yPosition))) //Circle
                     {
-                        if (CheckForUnbreakableTiles(Main.tile[xPosition, yPosition].type)) //Unbreakable
+                        ushort tile = Main.tile[xPosition, yPosition].type;
+                        if (CheckForUnbreakableTiles(tile) || !CanBreakTile(tile, PickPower)) //Unbreakable
                         {
 
                         }
                         else //Breakable
                         {
-                            
+                            // Seems unnecessary but left in just in case
                         }
 
                         if (WorldGen.TileEmpty((int)(x + position.X / 16.0f), (int)(y + position.Y / 16.0f)))

--- a/Projectiles/MediumExplosiveProjectile.cs
+++ b/Projectiles/MediumExplosiveProjectile.cs
@@ -22,6 +22,10 @@ namespace ExtraExplosives.Projectiles
 {
     public class MediumExplosiveProjectile : ModProjectile
     {
+        
+        // Variables
+        private const int PickPower = 0;
+        
         public override void SetStaticDefaults()
         {
             DisplayName.SetDefault("MediumExplosive");
@@ -66,7 +70,8 @@ namespace ExtraExplosives.Projectiles
 
                     if (Math.Sqrt(x * x + y * y) <= radius + 0.5 && (WorldGen.InWorld(xPosition, yPosition))) //Circle
                     {
-                        if (CheckForUnbreakableTiles(Main.tile[xPosition, yPosition].type)) //Unbreakable
+                        ushort tile = Main.tile[xPosition, yPosition].type;
+                        if (CheckForUnbreakableTiles(tile) || !CanBreakTile(tile, PickPower)) //Unbreakable
                         {
 
                         }

--- a/Projectiles/MegaExplosiveProjectile.cs
+++ b/Projectiles/MegaExplosiveProjectile.cs
@@ -22,6 +22,10 @@ namespace ExtraExplosives.Projectiles
 {
     public class MegaExplosiveProjectile : ModProjectile
     {
+        
+        // Variables
+        private const int PickPower = 0;
+        
         public override void SetStaticDefaults()
         {
             DisplayName.SetDefault("MegaExplosive");
@@ -66,7 +70,8 @@ namespace ExtraExplosives.Projectiles
 
                     if (Math.Sqrt(x * x + y * y) <= radius + 0.5 && (WorldGen.InWorld(xPosition, yPosition))) //Circle
                     {
-                        if (CheckForUnbreakableTiles(Main.tile[xPosition, yPosition].type)) //Unbreakable
+                        ushort tile = Main.tile[xPosition, yPosition].type;
+                        if (CheckForUnbreakableTiles(tile) || !CanBreakTile(tile, PickPower)) //Unbreakable
                         {
 
                         }

--- a/Projectiles/MeteoriteBusterProjectile.cs
+++ b/Projectiles/MeteoriteBusterProjectile.cs
@@ -22,6 +22,10 @@ namespace ExtraExplosives.Projectiles
 {
     public class MeteoriteBusterProjectile : ModProjectile
     {
+        
+        // Variables
+        private const int PickPower = 0;
+        
         public override void SetStaticDefaults()
         {
             DisplayName.SetDefault("MeteoriteBuster");
@@ -66,7 +70,8 @@ namespace ExtraExplosives.Projectiles
 
                     if (Math.Sqrt(x * x + y * y) <= radius + 0.5 && (WorldGen.InWorld(xPosition, yPosition))) //Circle
                     {
-                        if (CheckForUnbreakableTiles(Main.tile[xPosition, yPosition].type)) //Unbreakable
+                        ushort tile = Main.tile[xPosition, yPosition].type;
+                        if (CheckForUnbreakableTiles(tile) || !CanBreakTile(tile, PickPower)) //Unbreakable
                         {
 
                         }

--- a/Projectiles/NukeProjectile.cs
+++ b/Projectiles/NukeProjectile.cs
@@ -27,6 +27,7 @@ namespace ExtraExplosives.Projectiles
         //Variables
         bool firstTick;
         SoundEffectInstance sound;
+        private const int PickPower = 0;
 
         public override void SetStaticDefaults()
         {
@@ -133,7 +134,8 @@ namespace ExtraExplosives.Projectiles
                         Main.tile[xPosition, yPosition].liquid = Tile.Liquid_Water;
                         WorldGen.SquareTileFrame(xPosition, yPosition, true);
 
-                        if (CheckForUnbreakableTiles(Main.tile[xPosition, yPosition].type)) //Unbreakable
+                        ushort tile = Main.tile[xPosition, yPosition].type;
+                        if (CheckForUnbreakableTiles(tile) || !CanBreakTile(tile, PickPower)) //Unbreakable
                         {
                             if (Main.tile[xPosition, yPosition].type == TileID.BlueDungeonBrick || Main.tile[xPosition, yPosition].type == TileID.GreenDungeonBrick
                                 || Main.tile[xPosition, yPosition].type == TileID.PinkDungeonBrick || Main.tile[xPosition, yPosition].type == TileID.Cobalt || Main.tile[xPosition, yPosition].type == TileID.Palladium || Main.tile[xPosition, yPosition].type == TileID.Mythril || Main.tile[xPosition, yPosition].type == TileID.Orichalcum || Main.tile[xPosition, yPosition].type == TileID.Adamantite || Main.tile[xPosition, yPosition].type == TileID.Titanium ||

--- a/Projectiles/PhaseBombProjectile.cs
+++ b/Projectiles/PhaseBombProjectile.cs
@@ -12,10 +12,14 @@ namespace ExtraExplosives.Projectiles
 {
     public class PhaseBombProjectile : ModProjectile
     {
+        
+        // Variables
         Mod CalamityMod = ModLoader.GetMod("CalamityMod");
         Mod ThoriumMod = ModLoader.GetMod("ThoriumMod");
 
         internal static bool CanBreakWalls;
+        private const int PickPower = 0;
+        
         public override void SetStaticDefaults()
         {
             DisplayName.SetDefault("PhaseBomb");
@@ -81,7 +85,8 @@ namespace ExtraExplosives.Projectiles
 
                     if (Math.Sqrt(x * x + y * y) <= radius + 0.5 && (WorldGen.InWorld(xPosition, yPosition))) //Circle
                     {
-                        if (CheckForUnbreakableTiles(Main.tile[xPosition, yPosition].type)) //Unbreakable
+                        ushort tile = Main.tile[xPosition, yPosition].type;
+                        if (CheckForUnbreakableTiles(tile) || !CanBreakTile(tile, PickPower)) //Unbreakable
                         {
 
                         }

--- a/Projectiles/ReforgeBombProjectile.cs
+++ b/Projectiles/ReforgeBombProjectile.cs
@@ -23,11 +23,12 @@ namespace ExtraExplosives.Projectiles
 {
     public class ReforgeBombProjectile : ModProjectile
     {
+        
+        // Variables
         //Mod CalamityMod = ModLoader.GetMod("CalamityMod");
         //Mod ThoriumMod = ModLoader.GetMod("ThoriumMod");
 
         internal static bool CanBreakWalls;
-
 
         public override void SetStaticDefaults()
         {

--- a/Projectiles/SmallExplosiveProjectile.cs
+++ b/Projectiles/SmallExplosiveProjectile.cs
@@ -22,6 +22,10 @@ namespace ExtraExplosives.Projectiles
 {
     public class SmallExplosiveProjectile : ModProjectile
     {
+        
+        // Variables
+        private const int PickPower = 0;
+        
         public override void SetStaticDefaults()
         {
             DisplayName.SetDefault("SmallExplosive");
@@ -64,7 +68,8 @@ namespace ExtraExplosives.Projectiles
 
                     if (Math.Sqrt(x * x + y * y) <= radius + 0.5 && (WorldGen.InWorld(xPosition, yPosition))) //Circle
                     {
-                        if (CheckForUnbreakableTiles(Main.tile[xPosition, yPosition].type)) //Unbreakable
+                        ushort tile = Main.tile[xPosition, yPosition].type;
+                        if (CheckForUnbreakableTiles(tile) || !CanBreakTile(tile, PickPower)) //Unbreakable
                         {
 
                         }

--- a/Projectiles/TheLevelerProjectile.cs
+++ b/Projectiles/TheLevelerProjectile.cs
@@ -10,10 +10,13 @@ namespace ExtraExplosives.Projectiles
 {
     public class TheLevelerProjectile : ModProjectile
     {
+        
+        // Variables
         Mod CalamityMod = ModLoader.GetMod("CalamityMod");
         Mod ThoriumMod = ModLoader.GetMod("ThoriumMod");
 
         internal static bool CanBreakWalls;
+        private const int PickPower = 0;
 
         public override void SetStaticDefaults()
         {
@@ -82,7 +85,8 @@ namespace ExtraExplosives.Projectiles
 
                     if (WorldGen.InWorld(xPosition, yPosition)) //Circle
                     {
-                        if (CheckForUnbreakableTiles(Main.tile[xPosition, yPosition].type)) //Unbreakable
+                        ushort tile = Main.tile[xPosition, yPosition].type;
+                        if (CheckForUnbreakableTiles(tile) || !CanBreakTile(tile, PickPower)) //Unbreakable
                         {
                             if (Main.tile[xPosition, yPosition].type == TileID.DesertFossil)
                             {

--- a/Projectiles/TorchBombProjectile.cs
+++ b/Projectiles/TorchBombProjectile.cs
@@ -20,7 +20,6 @@ namespace ExtraExplosives.Projectiles
 {
     public class TorchBombProjectile : ModProjectile
     {
-
         public override void SetStaticDefaults()
         {
             DisplayName.SetDefault("Torch Bomb");

--- a/Projectiles/TrollBombProjectile.cs
+++ b/Projectiles/TrollBombProjectile.cs
@@ -23,6 +23,10 @@ namespace ExtraExplosives.Projectiles
 {
     public class TrollBombProjectile : ModProjectile
     {
+        
+        // Variables
+        private const int PickPower = 0;
+        
         public override void SetStaticDefaults()
         {
             DisplayName.SetDefault("TrollBomb");
@@ -84,7 +88,8 @@ namespace ExtraExplosives.Projectiles
 
                     if (Math.Sqrt(x * x + y * y) <= radius + 0.5) //Circle
                     {
-                        if (CheckForUnbreakableTiles(Main.tile[xPosition, yPosition].type)) //Unbreakable
+                        ushort tile = Main.tile[xPosition, yPosition].type;
+                        if (CheckForUnbreakableTiles(tile) || !CanBreakTile(tile, PickPower)) //Unbreakable
                         {
 
                         }


### PR DESCRIPTION
Update how explosive projectiles check for breakable tiles, they now use CanBreakTile. Additionally reformatted variables in most projectiles and added a pickpower const to all applicable  projectiles, set it to a default of 0

(Checked each explosive, working as expected mostly, bugs present not due to new tile checking)