### PR TITLE
Minor changes to config and unloading

### DIFF
--- a/ExtraExplosives.cs
+++ b/ExtraExplosives.cs
@@ -118,7 +118,7 @@ namespace ExtraExplosives
 		public static string GithubUserName => "VolcanicMG";
 		public static string GithubProjectName => "ExtraExplosives";
 		
-		// Create the item to item id reference (used with cpt explosive)
+		// Create the item to item id reference (used with cpt explosive) Needs to stay loaded
 		public ExtraExplosives()
 		{
 			mapItemToItemID = new Dictionary<int,int>();

--- a/ExtraExplosivesConfig.cs
+++ b/ExtraExplosivesConfig.cs
@@ -19,20 +19,19 @@ namespace ExtraExplosives
 		public bool CanBreakTiles;
 
 		[Header("Explosives Dust/Particle Settings")]
-		[Label("Set Dust/Particle amount" +
-			"\n1 = Max" +
-			"\n0 = None" +
-			"\nCurrent amount")]
+		[Label("Set Dust/Particle amount; Current Amount")]
+		[Tooltip("0 = No Dust; 1 = Lots of Dust")]
 		[Increment(0.1f)]
 		[Range(0f, 1f)]
 		[DefaultValue(1f)]
 		[Slider]
 		public float dustAmount;
-		
+
 		[Header("Dynamic Bullet Boom Integration")]
 		[Label("Use ammo from other mods in bullet booms? (Reload Required)")]
 		[Tooltip("Developmental Feature")]
-		[DefaultValue(true)]
+		[DefaultValue(false)]
+		[ReloadRequired]
 		public bool generateForeignBulletBooms;
 
 		public override void OnChanged()

--- a/ForeignModParsing.cs
+++ b/ForeignModParsing.cs
@@ -12,17 +12,18 @@ namespace ExtraExplosives
     public class ForeignModParsing
     {
         
-        private string version = Main.versionNumber;
+        //private string version = Main.versionNumber;
         // Uses layered ternary operations to get the current final item id of vanilla then supplements it with the additional tml ids
         private static int finalVanillaID = 3965;//((version.Contains("1.3.5")) ? 3929 : (version != "1.4.0.5") ? 5042 : 5044) + 36;
         private static int finalVanillaProj = 713;//((version.Contains("1.3.5")) ? 713 : (version != "1.4.0.5") ? 948 : 949);
-        static ArrayList modAmmo = new ArrayList();
-        static ArrayList modProj = new ArrayList();
+        private static ArrayList modAmmo = new ArrayList();
+        private static ArrayList modProj = new ArrayList();
 
         public static void PostLoad()
         {
             parseModdedItems();
             reactToModdedItems();
+            Unload();
         }
 
         private static void parseModdedItems()
@@ -100,9 +101,13 @@ namespace ExtraExplosives
                     
                 }
             }
+            sb.Clear();    // Clears the stringbuilder, just in case c# misses it
+        }
 
-            
-            // Will hold code to register ammo with bullet boom generation code
+        private static void Unload()    // Unloads everything to avoid any accidental memory leaking
+        {                        // This should be done by c# and tml, but always be cautious
+            modProj.Clear();
+            modAmmo.Clear();
         }
         
 


### PR DESCRIPTION
Changing config formatting, made modded bullet booms false by default, and made changing it require a reload for safety. Added an unload feature to the foreign mod parsing class to ensure everything is unloaded after use. (c# should already do this, but just in case)