### PR TITLE
Bug Fix - Ravenous Bomb accessory disabling normal bomb explosions (damage + effects)

### DIFF
--- a/Items/Accessories/BombardierClassAccessories/RavenousBomb.cs
+++ b/Items/Accessories/BombardierClassAccessories/RavenousBomb.cs
@@ -24,7 +24,7 @@ namespace ExtraExplosives.Items.Accessories.BombardierClassAccessories
         }
         public override void UpdateAccessory(Player player, bool hideVisual)
         {
-            player.EE().BombardEmblem = true;
+            player.EE().RavenousBomb = true;
         }
     }
 }


### PR DESCRIPTION
**Explanation:** In ` RavenousBomb.cs `, the ` BombardEmblem ` boolean of ` ExtraExplosivesPlayer.cs ` was being set to true. For some reason that boolean disables bombs from damaging NPCs and displaying dust effects. Since the Ravenous Bomb accessory doesn't overlap any of its functionality with the Bombard Emblem, I changed ` RavenousBomb.cs ` to set the ` RavenousBomb ` boolean of ` ExtraExplosivePlayer.cs ` to true.