### PR TITLE
Bug Fix - Ravenous Bomb accessory not implemented

### DIFF
--- a/ExtraExplosivesGlobalProjectile.cs
+++ b/ExtraExplosivesGlobalProjectile.cs
@@ -283,7 +283,41 @@ namespace ExtraExplosives
 
         public override bool PreKill(Projectile projectile, int timeLeft)
         {
-	        int type = projectile.type;	// Dont only so i didnt have to rename the variables below (copied from vanilla dont @ me), inefficient but who cares
+			// Applying the Ravenous Bomb lifesteal property
+			if (Main.player[projectile.owner].EE().RavenousBomb)
+			{
+				int damageDone = 0;
+				int projRadius = GetBombRadius(projectile);
+				foreach (NPC npc in Main.npc)
+				{
+					float dist = Vector2.Distance(npc.Center, projectile.Center);
+					if (dist / 16f <= projRadius)
+					{
+						if (npc.lifeMax > projectile.damage)
+							damageDone += projectile.damage;
+						else
+							damageDone += npc.lifeMax;
+					}
+				}
+				foreach (Player player in Main.player)
+				{
+					if (player == null || player.whoAmI == 255 || player.whoAmI == projectile.owner || !player.active)
+						continue;
+					float dist = Vector2.Distance(player.Center, projectile.Center);
+					if (dist / 16f <= projRadius)
+					{
+						damageDone += projectile.damage;
+					}
+				}
+				if (damageDone > 0)
+				{
+					int healPower = (int)(damageDone * 0.1);
+					Main.player[projectile.owner].HealEffect(healPower, true);
+				}
+			}
+
+			// Bombard Emblem stuff (I think? IDK, I didn't write this code. -- V8_Ninja)
+			int type = projectile.type;	// Dont only so i didnt have to rename the variables below (copied from vanilla dont @ me), inefficient but who cares
 	        if (type == ProjectileID.Bomb || type == ProjectileID.Dynamite || type == ProjectileID.StickyBomb ||
 	            type == ProjectileID.Explosives || type == ProjectileID.GrenadeII || type == ProjectileID.RocketII ||
 	            type == ProjectileID.ProximityMineII || type == ProjectileID.GrenadeIV || type == ProjectileID.RocketIV ||
@@ -421,7 +455,7 @@ namespace ExtraExplosives
 
 			        foreach (Player player in Main.player)
 			        {
-				        if (player == null || player.whoAmI == 255 || !player.active) return;
+				        if (player == null || player.whoAmI == 255 || !player.active) continue;
 				        if (!CanHitPlayer(projectile, player)) continue;
 				        if (player.EE().BlastShielding &&
 				            player.EE().BlastShieldingActive) continue;
@@ -437,12 +471,12 @@ namespace ExtraExplosives
 					        NetMessage.SendPlayerHurt(projectile.owner, PlayerDeathReason.ByProjectile(player.whoAmI, projectile.whoAmI), (int)(projectile.damage * (crit ? 1.5 : 1)), dir, crit, pvp: true, 0);
 				        }
 			        }
-            
 		        }
 		        
 		        ExplosionDamage();
 		        return false;
 	        }
+
 	        return base.PreKill(projectile, timeLeft);
         }
 
@@ -549,5 +583,43 @@ namespace ExtraExplosives
 		        if(mp.Bombshroom) GlobalMethods.InflictDubuff(BuffID.Venom, 15, projectile.Center, immune, projectile.owner, 173, 300);
 	        }
         }
+
+		private int GetBombRadius(Projectile projectile)
+		{
+			int radius = 3;
+
+			switch (projectile.type)
+            {
+				case ProjectileID.Bomb:
+				case ProjectileID.StickyBomb:
+				case ProjectileID.BouncyBomb:
+				case ProjectileID.BombFish:
+					radius = 4;
+					break;
+				case ProjectileID.Dynamite:
+				case ProjectileID.StickyDynamite:
+				case ProjectileID.BouncyDynamite:
+					radius = 7;
+					break;
+				case ProjectileID.GrenadeIV:
+				case ProjectileID.RocketIV:
+				case ProjectileID.ProximityMineIV:
+				case ProjectileID.RocketSnowmanIV:
+					radius = 5;
+					break;
+				case ProjectileID.Explosives:
+					radius = 10;
+					break;
+				default:
+					if (projectile.modProjectile is ExplosiveProjectile)
+                    {
+						ExplosiveProjectile exp = (ExplosiveProjectile)projectile.modProjectile;
+						radius = exp.radius;
+                    }
+					break;
+            }
+
+			return radius;
+		}
     }
 }


### PR DESCRIPTION
**Explanation:** During the lead-up to the new update, we forgot to implement the functionality for the Ravenous Bomb accessory. This commit fixes that issue, Almost all the work was done in the ` PreKill() ` method of ` ExtraExplosivesGlobalProjectile.cs `, so if something is wrong check out the code in that method first.