### PR TITLE
Bug Fix - Random Fuel descriptions have not been updated

### DIFF
--- a/ExtraExplosivesGlobalProjectile.cs
+++ b/ExtraExplosivesGlobalProjectile.cs
@@ -488,7 +488,7 @@ namespace ExtraExplosives
 	        {
 		        Vector2 npcPos = new Vector2();
 		        ExtraExplosivesPlayer mp = Main.player[projectile.owner].EE();
-		        if (mp.RandomFuel &&
+		        if (mp.RandomFuel ||
 		            mp.RandomFuelActive)	// Random fuel (working)
 		        {
 			        
@@ -508,32 +508,7 @@ namespace ExtraExplosives
 				        proj.timeLeft = 10;
 				        proj.velocity = projectile.velocity;
 				        proj.GetGlobalProjectile<ExtraExplosivesGlobalProjectile>().clone = true;
-			        }
-			        /*int buffId = 0;
-			        int dustId = 0;
-			        switch (Main.rand.Next(3)) // get the buff id
-			        {
-				        case 0:
-					        if (!mp.RandomFuelOnFire) break;
-					        buffId = BuffID.OnFire;
-					        dustId = 6;	// A red dust
-					        break;
-				        case 1:
-					        if (!mp.RandomFuelFrostburn) break;
-					        buffId = BuffID.Frostburn;
-					        dustId = 211;	// a bluish dust
-					        break;
-				        case 2:
-					        if (!mp.RandomFuelConfused) break;
-					        buffId = BuffID.Confused;
-					        dustId = 261;	// grey?
-					        break;
-				        default:	// if something breaks
-					        break;
-			        }
-			        // Random Fuel
-			        if(buffId != 0)GlobalMethods.InflictDubuff(buffId, 15, projectile.Center, projectile.owner, dustId, 300);*/
-			        
+			        }			        
 		        }
 
 		        if (mp.GlowingCompound && 

--- a/Items/Accessories/AnarchistCookbook/RandomFuel.cs
+++ b/Items/Accessories/AnarchistCookbook/RandomFuel.cs
@@ -9,9 +9,7 @@ namespace ExtraExplosives.Items.Accessories.AnarchistCookbook
         public override void SetStaticDefaults()
         {
             DisplayName.SetDefault("Random Fuel");
-            Tooltip.SetDefault("Randomly debuffs enemies\n" +
-                               "Enemies can be burnt, frozen, or confused\n" +
-                               "Debuffs can affect the player");
+            Tooltip.SetDefault("Makes explosives detonate twice");
         }
 
         public override void SetDefaults()

--- a/Items/Accessories/AnarchistCookbook/RandomNotes.cs
+++ b/Items/Accessories/AnarchistCookbook/RandomNotes.cs
@@ -9,10 +9,8 @@ namespace ExtraExplosives.Items.Accessories.AnarchistCookbook
         public override void SetStaticDefaults()
         {
             DisplayName.SetDefault("Random Notes");
-            Tooltip.SetDefault("Randomly debuffs enemies\n" +
-                               "Enemies can be burnt, frozen, or confused\n" +
-                               "Debuffs can affect the player\n" +
-                               "Explosives detonate twice as fast");
+            Tooltip.SetDefault("Makes explosives detonate twice\n" +
+                               "Halves fuse length of explosives");
         }
 
         public override void SetDefaults()

--- a/UI/AnarchistCookbookUI/RandomNotesPages.cs
+++ b/UI/AnarchistCookbookUI/RandomNotesPages.cs
@@ -52,8 +52,8 @@ namespace ExtraExplosives.UI.AnarchistCookbookUI
             RandomFuelFlavorText.TextColor = Color.Yellow;
             RandomFuelHeader.Append(RandomFuelFlavorText);
             
-            UIText RandomFuelDescription = new UIText("Explosives are infused with\n" +
-                                                            "one of three status effects");
+            UIText RandomFuelDescription = new UIText("Explosives will duplicate before\n" +
+                                                            "going off, causing two explosions");
             RandomFuelDescription.Top.Pixels = 40;
             RandomFuelDescription.HAlign = 0.7f;
             RandomFuelDescription.Left.Pixels = -10;
@@ -72,7 +72,7 @@ namespace ExtraExplosives.UI.AnarchistCookbookUI
             ShortFuzeFlavorText.TextColor = Color.Orange;
             ShortFuzeHeader.Append(ShortFuzeFlavorText);
             
-            UIText ShortFuzeDescription = new UIText("Allows for chaning the fuze\n" +
+            UIText ShortFuzeDescription = new UIText("Allows for changing the fuze\n" +
                                                            "length for most  explosives\n");
             ShortFuzeDescription.Top.Pixels = 40;
             ShortFuzeDescription.HAlign = 0.85f;


### PR DESCRIPTION
**Description:** It was reported that the Random Fuel accessory was not working as expected. After bringing up the issue with other developers, the functionality of the Random Fuel accessory (mostly) worked fine, but was changed from what it previously did. However, the descriptions for the various accessories relating to the Random Fuel functionality (mainly ` RandomFuel.cs `, ` RandomNotes.cs `, and ` RandomNotesPage.cs `) had not changed. This commit fixes those wrong descriptions.